### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vFabric Administration Server Ruby API
 
 The vFabric Administration Server (VAS) API is a Ruby library used for interacting with the
-[vFabric Administration Server](http://www.vmware.com/support/pubs/vfabric-vas.html).
+[vFabric Administration Server](https://www.vmware.com/support/pubs/vfabric-vas.html).
 
 VAS's primary mode of interaction is via RESTful interface. This API enables the use of VAS using
 rich Ruby types, eliminating the need for a detailed understanding of the REST API and its JSON
@@ -37,7 +37,7 @@ A number of [examples](https://github.com/vFabric/vas-ruby-api/tree/master/examp
 
 ### Documentation
 
-You may also like to look at the [API documentation](http://rubydoc.info/gems/vas/frames).
+You may also like to look at the [API documentation](https://www.rubydoc.info/gems/vas/frames).
 
 ##Licence
 

--- a/vas.gemspec
+++ b/vas.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.version       = "1.1.2.dev"
   gem.author        = "VMware"
   gem.email         = "support@vmware.com"
-  gem.homepage      = "http://vfabric.co"
+  gem.homepage      = "https://www.vmware.com/vfabric"
   gem.description   = "A Ruby API for VMware vFabric Administration Server"
   gem.summary       = "vFabric Administration Server Ruby API"
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://rubydoc.info/gems/vas/frames (301) with 1 occurrences migrated to:  
  https://www.rubydoc.info/gems/vas/frames ([https](https://rubydoc.info/gems/vas/frames) result SSLHandshakeException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.vmware.com/support/pubs/vfabric-vas.html with 1 occurrences migrated to:  
  https://www.vmware.com/support/pubs/vfabric-vas.html ([https](https://www.vmware.com/support/pubs/vfabric-vas.html) result 200).
* http://vfabric.co (301) with 1 occurrences migrated to:  
  https://www.vmware.com/vfabric ([https](https://vfabric.co) result 301).